### PR TITLE
Introduce replay filter options with "-D database" and "-U username" to

### DIFF
--- a/main.c
+++ b/main.c
@@ -67,6 +67,8 @@ static void help(FILE *f) {
 	fprintf(f, "   -b <timestamp> (start time for parsing logfile)\n");
 	fprintf(f, "   -e <timestamp> (end time for parsing logfile)\n");
 	fprintf(f, "   -q             ( \\' in string literal is a single quote)\n\n");
+	fprintf(f, "   -D <database>  (database name to use as filter for parsing logfile)\n");
+	fprintf(f, "   -U <username>  (username to use as filter for parsing logfile)\n");
 	fprintf(f, "Replay options:\n");
 	fprintf(f, "   -h <hostname>\n");
 	fprintf(f, "   -p <port>\n");
@@ -86,6 +88,7 @@ int main(int argc, char **argv) {
 	double factor = 1.0;
 	char *host = NULL, *encoding = NULL, *endptr, *passwd = NULL,
 		*outfilename = NULL, *infilename = NULL,
+		database_only[NAMELEN] = { '\0' }, username_only[NAMELEN] = { '\0' },
 		start_time[24] = { '\0' }, end_time[24] = { '\0' };
 	const char *errmsg;
 	unsigned long portnr = 0l, debug = 0l;
@@ -102,7 +105,7 @@ int main(int argc, char **argv) {
 
 	/* parse arguments */
 	opterr = 0;
-	while (-1 != (arg = getopt(argc, argv, "vfro:h:p:W:s:E:d:cb:e:qjX:"))) {
+	while (-1 != (arg = getopt(argc, argv, "vfro:h:p:W:s:E:d:cb:e:qjX:D:U:"))) {
 		switch (arg) {
 			case 'f':
 				parse_only = 1;
@@ -222,6 +225,16 @@ int main(int argc, char **argv) {
 			case 'q':
 				backslash_quote = 1;
 				break;
+			case 'D':
+				parse_opt = 1;
+
+				strncpy(database_only, optarg, NAMELEN - 1);
+				break;
+			case 'U':
+				parse_opt = 1;
+
+				strncpy(username_only, optarg, NAMELEN - 1);
+				break;
 			case 'j':
 				jump_enabled = 1;
 				break;
@@ -315,7 +328,9 @@ int main(int argc, char **argv) {
 			infilename,
 			csv,
 			(('\0' == start_time[0]) ? NULL : start_time),
-			(('\0' == end_time[0]) ? NULL : end_time)
+			(('\0' == end_time[0]) ? NULL : end_time),
+			(('\0' == database_only[0]) ? NULL : database_only),
+			(('\0' == username_only[0]) ? NULL : username_only)
 		))
 	{
 		rc = 1;

--- a/pgreplay.1
+++ b/pgreplay.1
@@ -95,6 +95,12 @@ the following single quote.
 This depends on configuration options like
 \fBstandard_conforming_strings\fR and is the default for server
 version 9.0 and less.
+.TP
+\fB-D\fR \fIdatabase\fR
+Only log entries related to the specified database will be parsed.
+.TP
+\fB-U\fR \fIusername\fR
+Only log entries related to the specified username will be parsed.
 .SS Replay options:
 .TP
 \fB-h\fR \fIhostname\fR

--- a/pgreplay.h
+++ b/pgreplay.h
@@ -18,6 +18,9 @@
 #include <stdint.h>
 #include <sys/time.h>
 
+/* maximum length of a name in PostgreSQL */
+#define NAMELEN 64
+
 /* types for replay items */
 typedef enum {
 	pg_connect = 0,
@@ -32,7 +35,7 @@ typedef enum {
    the definition is in replay_item.c */
 typedef struct replay_item replay_item;
 
-typedef int (replay_item_provider_init)(const char *, int, const char *, const char *);
+typedef int (replay_item_provider_init)(const char *, int, const char *, const char *, const char *, const char *);
 typedef replay_item *(replay_item_provider)();
 typedef void (replay_item_provider_finish)();
 

--- a/pgreplay.html
+++ b/pgreplay.html
@@ -207,6 +207,16 @@ options like <b>standard_conforming_strings</b> and is the
 default for server version 9.0 and less.</p></td>
 </table>
 
+<p style="margin-left:11%;"><b>-D</b> <i>database</i></p>
+
+<p style="margin-left:22%;">Only log entries related to the
+specified database name will be parsed.</p>
+
+<p style="margin-left:11%;"><b>-U</b> <i>username</i></p>
+
+<p style="margin-left:22%;">Only log entries related to the
+specified username will be parsed.</p>
+
 <p style="margin-left:11%; margin-top: 1em"><b>Replay
 options: <br>
 -h</b> <i>hostname</i></p>

--- a/replayfile.c
+++ b/replayfile.c
@@ -123,7 +123,7 @@ static int read_string(char ** const s) {
 	return 1;
 }
 	
-int file_provider_init(const char *infile, int cvs, const char *begin_time, const char *end_time) {
+int file_provider_init(const char *infile, int cvs, const char *begin_time, const char *end_time, const char *db_only, const char *usr_only) {
 	int rc = 1;
 	debug(3, "Entering file_provider_init%s\n", "");
 


### PR DESCRIPTION
only parse log entries related to the specified database name and/or
username. By default pgreplay replay the log entries of a complete
PostgreSQL instance. Using those command line options you will be able
to replay only statements related to a single database and/or executed
by a single username.
