### PR TITLE
Fix database name comparison when option -D is in use

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -1334,7 +1334,7 @@ replay_item * parse_provider() {
 					strcat(quote_name, database);
 					strcat(quote_name, "\\");
 				}
-				if ((NULL != database_only) && (NULL == strstr(quote_name, quote_name))) {
+				if ((NULL != database_only) && (NULL == strstr(database_only, quote_name))) {
 					debug(2, "Database \"%s\" does not match filter, skipped log entry\n", database);
 					free(message);
 					if (! csv && detail) {


### PR DESCRIPTION
Option -D (parsing filter for a database only) was broken in commit 5a3406a79327989d390e8d67a2811ad4540efc98