### PR TITLE
Add Dry run mode (option -N)

### DIFF
--- a/database.c
+++ b/database.c
@@ -1015,12 +1015,27 @@ int database_consumer_dry_run(replay_item *item) {
 		fstmt_set_dr = 1;
 	}
 
+	if (type == pg_execute || type == pg_exec_prepared || type == pg_connect || type == pg_disconnect) {
+		++stat_actions;
+	}
+
 	if (type == pg_execute || type == pg_exec_prepared) {
 		++stat_stmt;
 	}
 
 	if (type == pg_prepare) {
 		++stat_prep;
+	}
+
+	if (type == pg_connect) {
+		++stat_sesscnt;
+		if (++stat_sessions > stat_sessmax) {
+			stat_sessmax = stat_sessions;
+		}
+	}
+
+	if (type == pg_disconnect) {
+		--stat_sessions;
 	}
 
 	replay_free(item);

--- a/main.c
+++ b/main.c
@@ -77,6 +77,7 @@ static void help(FILE *f) {
 	fprintf(f, "   -E <encoding>  (server encoding)\n");
 	fprintf(f, "   -j             (skip idle time during replay)\n");
 	fprintf(f, "   -X <options>   (extra libpq connect options)\n\n");
+	fprintf(f, "   -N             (dry-run, will replay file without running queries)\n\n");
 	fprintf(f, "Debugging:\n");
 	fprintf(f, "   -d <level>     (level between 1 and 3)\n");
 	fprintf(f, "   -v             (prints version and exits)\n");
@@ -84,7 +85,7 @@ static void help(FILE *f) {
 
 int main(int argc, char **argv) {
 	int arg, parse_only = 0, replay_only = 0, port = -1, csv = 0,
-		parse_opt = 0, replay_opt = 0, rc = 0;
+		parse_opt = 0, replay_opt = 0, rc = 0, dry_run = 0;
 	double factor = 1.0;
 	char *host = NULL, *encoding = NULL, *endptr, *passwd = NULL,
 		*outfilename = NULL, *infilename = NULL,
@@ -105,7 +106,7 @@ int main(int argc, char **argv) {
 
 	/* parse arguments */
 	opterr = 0;
-	while (-1 != (arg = getopt(argc, argv, "vfro:h:p:W:s:E:d:cb:e:qjX:D:U:"))) {
+	while (-1 != (arg = getopt(argc, argv, "vfro:h:p:W:s:E:d:cb:e:qjNX:D:U:"))) {
 		switch (arg) {
 			case 'f':
 				parse_only = 1;
@@ -275,6 +276,11 @@ int main(int argc, char **argv) {
 
 				extra_connstr = optarg;
 				break;
+			case 'N':
+				replay_opt = 1;
+
+				dry_run = 1;
+				break;
 			case '?':
 				if (('?' == optopt) || ('h' == optopt)) {
 					help(stdout);
@@ -351,7 +357,11 @@ int main(int argc, char **argv) {
 	} else {
 		consumer_init = &database_consumer_init;
 		consumer_finish = &database_consumer_finish;
-		consumer = &database_consumer;
+		if (0 == dry_run) {
+			consumer = &database_consumer;
+		} else {
+			consumer = &database_consumer_dry_run;
+		}
 	}
 
 	/* main loop */
@@ -397,7 +407,7 @@ int main(int argc, char **argv) {
 	}
 
 	(*provider_finish)();
-	(*consumer_finish)();
+	(*consumer_finish)(dry_run);
 
 	return rc;
 }

--- a/parse.c
+++ b/parse.c
@@ -80,6 +80,8 @@ static unsigned long lineno = 0;
 /* offset for time values (what mktime(3) makes of 2000-01-01 00:00:00)
    used to make timestamps independent of local time and broken mktime */
 static time_t epoch;
+/*Time of the first and last statement that we parse*/
+static struct timeval first_stmt_time_parse, last_stmt_time_parse;
 
 /* statistics */
 static unsigned long stat_simple = 0;     /* simple statements */
@@ -1217,6 +1219,10 @@ static int parse_bind_args(char *** const result, char *line) {
 }
 
 static void print_parse_statistics() {
+	int length_days, length_hours, length_minutes;
+	double length_seconds;
+	struct timeval total_length;
+
 	fprintf(sf, "\nParse statistics\n");
 	fprintf(sf, "================\n\n");
 	fprintf(sf, "Log lines read: %lu\n", lineno);
@@ -1233,6 +1239,27 @@ static void print_parse_statistics() {
 	}
 	fprintf(sf, "Cancel requests processed: %lu\n", stat_cancel);
 	fprintf(sf, "Fast-path function calls ignored: %lu\n", stat_fastpath);
+	/*Calculate lengh of the recorded workload*/
+	timersub(&last_stmt_time_parse, &first_stmt_time_parse, &total_length);
+	length_days = total_length.tv_sec / 86400;
+	total_length.tv_sec -= length_days * 86400;
+	length_hours = total_length.tv_sec / 3600;
+	total_length.tv_sec -= length_hours * 3600;
+	length_minutes = total_length.tv_sec / 60;
+	total_length.tv_sec -= length_minutes * 60;
+	length_seconds = total_length.tv_sec + total_length.tv_usec / 1000000.0;
+
+	fprintf(sf, "Duration of recorded workload:");
+	if (length_days > 0) {
+		fprintf(sf, " %d days", length_days);
+	}
+	if (length_hours > 0) {
+		fprintf(sf, " %d hours", length_hours);
+	}
+	if (length_minutes > 0) {
+		fprintf(sf, " %d minutes", length_minutes);
+	}
+	fprintf(sf, " %.3f seconds\n", length_seconds);
 }
 
 int parse_provider_init(const char *in, int parse_csv, const char *begin, const char *end, const char *db_only, const char *usr_only) {
@@ -1306,6 +1333,7 @@ replay_item * parse_provider() {
 	struct connection *conn = NULL;
 	/* queue of up to two replay items */
 	static replay_item *queue[2] = { NULL, NULL };
+	static int first_stmt_time_parse_set = 0;
 
 	debug(3, "Entering parse_provider%s\n", "");
 
@@ -1575,6 +1603,15 @@ replay_item * parse_provider() {
 		/* remember time */
 		oldtime.tv_sec  = replay_get_time(r)->tv_sec;
 		oldtime.tv_usec = replay_get_time(r)->tv_usec;
+
+		last_stmt_time_parse.tv_sec = replay_get_time(r)->tv_sec;
+		last_stmt_time_parse.tv_usec = replay_get_time(r)->tv_usec;
+		if (! first_stmt_time_parse_set) {
+			first_stmt_time_parse.tv_sec = replay_get_time(r)->tv_sec;
+			first_stmt_time_parse.tv_usec = replay_get_time(r)->tv_usec;
+
+			first_stmt_time_parse_set = 1;
+		}
 	}
 
 	if (-1 == status) {
@@ -1592,6 +1629,7 @@ replay_item * parse_provider() {
 			queue[1] = NULL;
 		}
 	}
+
 
 	if (r && (1 <= debug_level) && (end_item != r)) {
 		replay_print_debug(r);

--- a/pgreplay.1
+++ b/pgreplay.1
@@ -135,6 +135,11 @@ If all connections are idle, jump ahead to the next request instead of
 sleeping. This will speed up replay. Execution delays will still be reported
 correctly, but replay statistics will not contain the idle time.
 .TP
+\fB-N\fR
+Dry run mode. No connections to the server are made.
+Useful for checking if the replay file is corrupted or to have stats
+about the replay file (number of statements, original duration,...)
+.TP
 \fB-X\fR \fIoptions\fR
 Extra connection options for replay connections.  These must be libpq
 connection options specified in the format \(oqoption=value [...]\(cq.

--- a/pgreplay.h
+++ b/pgreplay.h
@@ -149,6 +149,7 @@ extern replay_item_consumer_finish file_consumer_finish;
 /*************************/
 
 extern replay_item_consumer database_consumer;
+extern replay_item_consumer database_consumer_dry_run;
 extern replay_item_consumer_init database_consumer_init;
 extern replay_item_consumer_finish database_consumer_finish;
 

--- a/pgreplay.h
+++ b/pgreplay.h
@@ -41,7 +41,7 @@ typedef void (replay_item_provider_finish)();
 
 typedef int (replay_item_consumer_init)(const char *, const char *, int, const char *, double);
 typedef int (replay_item_consumer)(replay_item *);
-typedef void (replay_item_consumer_finish)();
+typedef void (replay_item_consumer_finish)(int);
 
 /* hash value for session ID is computed as low byte of background PID */
 #define hash_session(x) (unsigned char)(x & 0xFF);

--- a/replayfile.c
+++ b/replayfile.c
@@ -122,7 +122,7 @@ static int read_string(char ** const s) {
 
 	return 1;
 }
-	
+
 int file_provider_init(const char *infile, int cvs, const char *begin_time, const char *end_time, const char *db_only, const char *usr_only) {
 	int rc = 1;
 	debug(3, "Entering file_provider_init%s\n", "");
@@ -321,7 +321,7 @@ int file_consumer_init(const char *outfile, const char *host, int port, const ch
 	return 1;
 }
 
-void file_consumer_finish() {
+void file_consumer_finish(int dry_run) {
 	debug(3, "Entering file_consumer_finish%s\n", "");
 
 	if (1 != filed) {

--- a/test/dryrun_out.exp
+++ b/test/dryrun_out.exp
@@ -1,0 +1,24 @@
+
+Replay statistics (dry run)
+=================
+
+Duration of recorded workload: 37.764 seconds
+Speed factor for replay: 1.000
+Total run time: 0.000 seconds
+Maximum lag behind schedule: 0 seconds
+Calls to the server: 31
+Total number of connections: 4
+Maximum number of concurrent connections: 4
+Average number of concurrent connections: 0.000
+SQL statements executed: 18
+(0 or 0.000% of these completed with error)
+Maximum number of concurrent SQL statements: 0
+Average number of concurrent SQL statements: 0.000
+Average SQL statement duration: 0.000 seconds
+Maximum SQL statement duration: 0.000 seconds
+Statement duration histogram:
+  0    to 0.02 seconds: -nan%
+  0.02 to 0.1  seconds: -nan%
+  0.1  to 0.5  seconds: -nan%
+  0.5  to 2    seconds: -nan%
+     over 2    seconds: -nan%

--- a/test/parse_csv_out.exp
+++ b/test/parse_csv_out.exp
@@ -12,3 +12,4 @@ Different named prepared SQL statements processed: 1
 (average reuse count 1.000)
 Cancel requests processed: 1
 Fast-path function calls ignored: 5
+Duration of recorded workload: 37.764 seconds

--- a/test/parse_err_out.exp
+++ b/test/parse_err_out.exp
@@ -12,3 +12,4 @@ Different named prepared SQL statements processed: 1
 (average reuse count 1.000)
 Cancel requests processed: 1
 Fast-path function calls ignored: 5
+Duration of recorded workload: 37.764 seconds

--- a/test/runtest.sh.in
+++ b/test/runtest.sh.in
@@ -100,6 +100,29 @@ if [ $? -ne 0 ]; then
 	rm -f replay.out replay.err replay.diff
 	exit 1
 fi
+echo "Testing dry run ... "
+../pgreplay -r -N -E UTF8 replayfile 2>dryrun.err|sed '/calls per second/d' >dryrun.out
+if [ $? -ne 0 ]; then
+	echo "command failed, error messages:"
+	cat dryrun.err
+	rm -f dryrun.out dryrun.err
+	exit 1
+fi
+diff -b dryrun.out dryrun_out.exp >dryrun.diff
+if [ $? -ne 0 ]; then
+	echo "unexpected output, difference to expected:"
+	cat dryrun.diff
+	rm -f dryrun.out dryrun.err dryrun.diff
+	exit 1
+fi
+diff -b dryrun.err dryrun_err.exp >dryrun.diff
+if [ $? -ne 0 ]; then
+	echo "unexpected messages, difference to expected:"
+	cat dryrun.diff
+	rm -f dryrun.out dryrun.err dryrun.diff
+	exit 1
+fi
+
 echo "ok"
-rm -f replay.out replay.err replay.diff
+rm -f replay.out replay.err replay.diff dryrun.out dryrun.err dryrun.diff
 exit 0


### PR DESCRIPTION
This will go through the replay file and consume the records
without going to the DB. Ideal for knowing the number of statements
and for knowing if the replay file is corrupted or not.