### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:22.10
+
+RUN TZ=UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y tzdata make gcc libc6-dev postgresql-14 libpq-dev postgresql-doc-14 git ca-certificates && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /root
+RUN git clone https://github.com/laurenz/pgreplay.git
+WORKDIR /root/pgreplay
+RUN ./configure --with-postgres=/usr/bin
+RUN make
+RUN make install
+RUN ln -s /root/pgreplay/pgreplay /usr/local/bin
+

--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ The following utilities are only necessary if you intend to develop pgreplay:
 - GNU tar to `make tarball` (unless you want to roll it by hand)
 - groff to make the HTML documentation with `make html`
 
+Docker
+------
+You can use the provided `Dockerfile` to run `pgreplay`.
+Build the image:
+```
+# build the image
+docker build -t laurenz/pgreplay -f Dockerfile .
+
+# and run it
+docker run --rm -ti -v $(pwd):/app -w /app laurenz/pgreplay pgreplay -h
+```
+
 Testing
 -------
 


### PR DESCRIPTION
Hi @laurenz 
I've opened this PR to add a Dockerfile to your project, allowing people to use the `pgreplay` tool without needing to have PostgreSQL or any build tool installed on their machines.
The Dockerfile has Postgresql version 14 hardcoded, but I can easily change it to "the latest available version". I have hardcoded it at 14, so it's more predictable down the line; if someone has problems with their Dockerfile, we know they will be using Postgres 14.
Happy to improve the PR as you see fit.
Thanks for the work you've done